### PR TITLE
UO-P0-05: enable daily Postgres logical backups in dev (14-day retention)

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/identity/auth/auth-service/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/identity/auth/auth-service/values-dev.yaml
@@ -133,6 +133,20 @@ secrets:
 # PostgreSQL subchart (only deployed when appType=service and database.enabled=true)
 postgresql:
   enabled: true
+  # Logical dumps (UO-P0-05): daily pg_dumpall to a Longhorn PVC,
+  # 14-day retention enforced by the trailing find -delete.
+  backup:
+    enabled: true
+    cronjob:
+      schedule: "@daily"
+      concurrencyPolicy: Forbid
+      command:
+        - /bin/sh
+        - -c
+        - "pg_dumpall --clean --if-exists --load-via-partition-root --quote-all-identifiers --no-password --file=${PGDUMP_DIR}/pg_dumpall-$(date '+%Y-%m-%d-%H-%M').pgdump && find ${PGDUMP_DIR} -type f -name '*.pgdump' -mtime +14 -delete"
+      storage:
+        storageClass: longhorn
+        size: 2Gi
   # Image will use global Harbor registry - run mirror-bitnami-images.sh to populate Harbor
   image:
     repository: bitnami/postgresql

--- a/clusters/unifyops-home/apps/unifyops/identity/user/user-service/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/identity/user/user-service/values-dev.yaml
@@ -148,6 +148,20 @@ secrets:
 # PostgreSQL subchart (only deployed when appType=service and database.enabled=true)
 postgresql:
   enabled: true
+  # Logical dumps (UO-P0-05): daily pg_dumpall to a Longhorn PVC,
+  # 14-day retention enforced by the trailing find -delete.
+  backup:
+    enabled: true
+    cronjob:
+      schedule: "@daily"
+      concurrencyPolicy: Forbid
+      command:
+        - /bin/sh
+        - -c
+        - "pg_dumpall --clean --if-exists --load-via-partition-root --quote-all-identifiers --no-password --file=${PGDUMP_DIR}/pg_dumpall-$(date '+%Y-%m-%d-%H-%M').pgdump && find ${PGDUMP_DIR} -type f -name '*.pgdump' -mtime +14 -delete"
+      storage:
+        storageClass: longhorn
+        size: 2Gi
   # Image will use global Harbor registry - run mirror-bitnami-images.sh to populate Harbor
   image:
     repository: bitnami/postgresql


### PR DESCRIPTION
Enables the vendored Bitnami backup cronjob for both dev databases (pg_dumpall to a 2Gi Longhorn PVC, 14-day retention). Verified by helm-templating the deployed 0.1.15 chart with these values.

Part of Phase 0 (UNIFYOPS-MVP-IMPLEMENTATION-PLAN §4, UO-P0-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bay1BmnPqYJcp4zXVHY38f