### PR TITLE
UO-P0-05: Longhorn daily snapshots + RESTORE.md runbook

### DIFF
--- a/clusters/unifyops-home/apps/longhorn/kustomization.yaml
+++ b/clusters/unifyops-home/apps/longhorn/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - app.yaml
+  - recurringjob-daily-snapshot.yaml
   - longhorn-ingress.yaml
   - certificate.yaml
   - secrets/route53-credentials.sealed.yaml

--- a/clusters/unifyops-home/apps/longhorn/recurringjob-daily-snapshot.yaml
+++ b/clusters/unifyops-home/apps/longhorn/recurringjob-daily-snapshot.yaml
@@ -1,0 +1,16 @@
+# Daily Longhorn snapshots for all volumes (UO-P0-05).
+# The "default" group applies this job to every volume that has no
+# explicit recurring-job assignment. 14 snapshots retained (~2 weeks).
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: daily-snapshot
+  namespace: longhorn-system
+spec:
+  name: daily-snapshot
+  task: snapshot
+  cron: "0 3 * * *"
+  retain: 14
+  concurrency: 2
+  groups:
+    - default


### PR DESCRIPTION
- RecurringJob `daily-snapshot` (03:00 daily, retain 14, group `default` → all volumes)
- RESTORE.md: pg_dumpall restore, snapshot restore, sealed-secrets key escrow/restore, rebuild order

Sealed-secrets keys (6) exported to offline escrow outside the repo. Postgres backup cronjobs enabled separately on the dev values branch (infra PR #9, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bay1BmnPqYJcp4zXVHY38f