### PR TITLE
ARC bootstrap: upstream runner image + Dockerfile curl fix

### DIFF
--- a/clusters/unifyops-home/apps/github-runner/app-runners.yaml
+++ b/clusters/unifyops-home/apps/github-runner/app-runners.yaml
@@ -27,14 +27,20 @@ spec:
         containerMode:
           type: "dind"
 
-        # Custom runner image from Harbor registry
+        # TEMPORARY BOOTSTRAP (UO-P0): upstream runner image while the
+        # hardened Harbor image is rebuilt by CI. v1.8 bundles runner
+        # 2.329.0, which GitHub deprecated ("cannot receive messages"),
+        # and pushing the rebuilt image requires a working runner.
+        # Revert to harbor.unifyops.io/library/arc-runner-unifyops:v1.9
+        # once the build-runner-image workflow has pushed it.
         template:
           spec:
             containers:
             - name: runner
-              image: harbor.unifyops.io/library/arc-runner-unifyops:v1.8
+              image: ghcr.io/actions/actions-runner:latest
               imagePullPolicy: Always
-            # Harbor registry credentials
+              command: ["/home/runner/run.sh"]
+            # Harbor registry credentials (kept for the v1.9 revert)
             imagePullSecrets:
             - name: harbor-registry-secret
   destination:

--- a/clusters/unifyops-home/apps/github-runner/runner-image/Dockerfile
+++ b/clusters/unifyops-home/apps/github-runner/runner-image/Dockerfile
@@ -49,7 +49,7 @@
         apt-get update && \
         apt-get install -y --no-install-recommends \
             ca-certificates \
-            curl=7.* \
+            curl=8.* \
             git=1:2.* \
             jq=1.* \
             tar \


### PR DESCRIPTION
Runner v1.8 image bundles deprecated runner 2.329.0 → all runners crash-loop, every arc-runners job queues forever. This bootstraps runners on the upstream image (current runner 2.335.1) so the CI workflow that rebuilds the hardened image can actually run; reverts to arc-runner-unifyops:v1.9 after the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bay1BmnPqYJcp4zXVHY38f