### PR TITLE
ARC: back to hardened runner image v1.9

### DIFF
--- a/clusters/unifyops-home/apps/github-runner/app-runners.yaml
+++ b/clusters/unifyops-home/apps/github-runner/app-runners.yaml
@@ -27,20 +27,18 @@ spec:
         containerMode:
           type: "dind"
 
-        # TEMPORARY BOOTSTRAP (UO-P0): upstream runner image while the
-        # hardened Harbor image is rebuilt by CI. v1.8 bundles runner
-        # 2.329.0, which GitHub deprecated ("cannot receive messages"),
-        # and pushing the rebuilt image requires a working runner.
-        # Revert to harbor.unifyops.io/library/arc-runner-unifyops:v1.9
-        # once the build-runner-image workflow has pushed it.
+        # Hardened runner image (kubectl/helm/yq/jq), rebuilt via the
+        # build-runner-image workflow in KominskyOrg/unifyops (CI-owned
+        # Harbor pushes). Rebuild + bump BEFORE GitHub deprecates the
+        # bundled actions/runner version (v1.8 died that way).
         template:
           spec:
             containers:
             - name: runner
-              image: ghcr.io/actions/actions-runner:latest
+              image: harbor.unifyops.io/library/arc-runner-unifyops:v1.9
               imagePullPolicy: Always
               command: ["/home/runner/run.sh"]
-            # Harbor registry credentials (kept for the v1.9 revert)
+            # Harbor registry credentials
             imagePullSecrets:
             - name: harbor-registry-secret
   destination:


### PR DESCRIPTION
Reverts the temporary upstream-image bootstrap (PR #13). v1.9 = current actions/runner 2.335.1 + kubectl/helm/yq/jq, built and pushed by the build-runner-image CI workflow. Merge after v1.9 is confirmed in Harbor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bay1BmnPqYJcp4zXVHY38f