### PR TITLE
fix(runner-image): retry+resume helm download

### DIFF
--- a/clusters/unifyops-home/apps/github-runner/runner-image/Dockerfile
+++ b/clusters/unifyops-home/apps/github-runner/runner-image/Dockerfile
@@ -73,7 +73,10 @@
     # --------------------------------------------------------------------
     # Install helm
     # --------------------------------------------------------------------
-    RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz && \
+    # get.helm.sh (Fastly) resets long transfers from this cluster; retry with
+    # resume so partial downloads complete. sha256sum still guards integrity.
+    RUN curl -fSL --retry 8 --retry-delay 5 --retry-all-errors --continue-at - \
+            "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz && \
         echo "${HELM_SHA256}  /tmp/helm.tar.gz" | sha256sum -c - && \
         tar -zxf /tmp/helm.tar.gz -C /tmp && \
         install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm && \


### PR DESCRIPTION
get.helm.sh (Fastly) consistently resets the ~16MB helm tarball transfer mid-download from the cluster (runs 28745978239 and 28746282690, both `curl: (35) Recv failure` at the same step, while larger kubectl downloads from dl.k8s.io succeed). Add `--retry 8 --retry-all-errors --continue-at -` so the download resumes across resets; the existing sha256sum check still guards integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bay1BmnPqYJcp4zXVHY38f