### PR TITLE
UO-P1-01: shared PostgreSQL for uo-dev (identity+platform schemas)

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/postgresql/dev/backup.yaml
+++ b/clusters/unifyops-home/apps/unifyops/postgresql/dev/backup.yaml
@@ -1,0 +1,89 @@
+# Logical dumps for the shared instance, mirroring the UO-P0-05 pattern used by
+# the per-service databases: daily pg_dumpall to a Longhorn PVC, 14-day
+# retention enforced by the trailing find -delete.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unifyops-postgresql-pgdumpall
+  namespace: uo-dev
+  labels:
+    app: unifyops-postgresql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: unifyops-postgresql-pgdumpall
+  namespace: uo-dev
+  labels:
+    app: unifyops-postgresql
+spec:
+  schedule: "@daily"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: unifyops-postgresql
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 1001
+          containers:
+            - name: pgdumpall
+              image: harbor.unifyops.io/library/bitnami/postgresql:16.4.0-debian-12-r13
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1001
+                seccompProfile:
+                  type: RuntimeDefault
+              command:
+                - /bin/sh
+                - -c
+                - >-
+                  pg_dumpall --clean --if-exists --load-via-partition-root
+                  --quote-all-identifiers --no-password
+                  --file=${PGDUMP_DIR}/pg_dumpall-$(date '+%Y-%m-%d-%H-%M').pgdump
+                  && find ${PGDUMP_DIR} -type f -name '*.pgdump' -mtime +14 -delete
+              env:
+                - name: PGDUMP_DIR
+                  value: /backup/pgdumpall
+                - name: PGHOST
+                  value: unifyops-postgresql
+                - name: PGPORT
+                  value: "5432"
+                - name: PGUSER
+                  value: postgres
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: unifyops-postgresql-secret
+                      key: postgres-password
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              volumeMounts:
+                - name: dumps
+                  mountPath: /backup/pgdumpall
+          volumes:
+            - name: dumps
+              persistentVolumeClaim:
+                claimName: unifyops-postgresql-pgdumpall

--- a/clusters/unifyops-home/apps/unifyops/postgresql/dev/configmap-initdb.yaml
+++ b/clusters/unifyops-home/apps/unifyops/postgresql/dev/configmap-initdb.yaml
@@ -1,0 +1,17 @@
+# First-boot init: create the two schemas (plan §2.4). Runs only when the data
+# volume is empty; the identity-service Alembic baseline also does
+# CREATE SCHEMA IF NOT EXISTS, so a pre-existing volume is not a problem.
+# Everything runs as the postgres superuser for now, matching the existing
+# per-service instances; dedicated per-schema roles are later hardening.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unifyops-postgresql-init-scripts
+  namespace: uo-dev
+  labels:
+    app: unifyops-postgresql
+data:
+  00-schemas.sql: |
+    \connect unifyops
+    CREATE SCHEMA IF NOT EXISTS identity;
+    CREATE SCHEMA IF NOT EXISTS platform;

--- a/clusters/unifyops-home/apps/unifyops/postgresql/dev/service.yaml
+++ b/clusters/unifyops-home/apps/unifyops/postgresql/dev/service.yaml
@@ -1,0 +1,37 @@
+# Stable DNS name services use: unifyops-postgresql.uo-dev.svc (or just
+# unifyops-postgresql from inside the namespace).
+apiVersion: v1
+kind: Service
+metadata:
+  name: unifyops-postgresql
+  namespace: uo-dev
+  labels:
+    app: unifyops-postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      protocol: TCP
+  selector:
+    app: unifyops-postgresql
+---
+# Headless service backing the StatefulSet's stable pod identity.
+apiVersion: v1
+kind: Service
+metadata:
+  name: unifyops-postgresql-hl
+  namespace: uo-dev
+  labels:
+    app: unifyops-postgresql
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      protocol: TCP
+  selector:
+    app: unifyops-postgresql

--- a/clusters/unifyops-home/apps/unifyops/postgresql/dev/statefulset.yaml
+++ b/clusters/unifyops-home/apps/unifyops/postgresql/dev/statefulset.yaml
@@ -1,0 +1,147 @@
+# UO-P1-01: one shared PostgreSQL instance for the uo-dev environment.
+# Replaces the per-service Bitnami subchart pattern (auth-service-postgresql /
+# user-service-postgresql stay up during the Phase 1 transition; retired in UO-P1-10).
+# Database `unifyops` carries the `identity` and `platform` schemas (plan §2.4).
+# Image is the Harbor-hosted copy of the exact tag the existing instances run.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unifyops-postgresql
+  namespace: uo-dev
+  labels:
+    app: unifyops-postgresql
+spec:
+  replicas: 1
+  serviceName: unifyops-postgresql-hl
+  selector:
+    matchLabels:
+      app: unifyops-postgresql
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: unifyops-postgresql
+    spec:
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        # Longhorn volumes come up root-owned; the Bitnami image runs as 1001.
+        - name: volume-permissions
+          image: busybox:1.35
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - chown -R 1001:1001 /bitnami/postgresql && chmod -R 755 /bitnami/postgresql
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/postgresql
+      containers:
+        - name: postgresql
+          image: harbor.unifyops.io/library/bitnami/postgresql:16.4.0-debian-12-r13
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: /bitnami/postgresql
+            - name: PGDATA
+              value: /bitnami/postgresql/data
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: unifyops-postgresql-secret
+                  key: postgres-password
+            - name: POSTGRES_DATABASE
+              value: unifyops
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: error
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: pgaudit
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "postgres" -d "dbname=unifyops" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "postgres" -d "dbname=unifyops" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: custom-init-scripts
+          configMap:
+            name: unifyops-postgresql-init-scripts
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi

--- a/clusters/unifyops-home/secrets/dev/kustomization.yaml
+++ b/clusters/unifyops-home/secrets/dev/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: uo-dev
 resources:
   - auth-jwt-sealed.yaml
   - auth-service-api-keys-sealed.yaml
+  - unifyops-postgresql-sealed.yaml

--- a/clusters/unifyops-home/secrets/dev/unifyops-postgresql-sealed.yaml
+++ b/clusters/unifyops-home/secrets/dev/unifyops-postgresql-sealed.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: unifyops-postgresql-secret
+  namespace: uo-dev
+spec:
+  encryptedData:
+    postgres-password: AgChM/J5Ywtw5jJkRleQhWBy3weOeRX2sqxzz6nLzyvYoLc+MYAiAi0jcAQr4+i6UqWSUcYnZWLnRoy0rR6sqMeCTF3ihgZ7KZgO0MQ6YEdIa3d2D0T5Hxft6aEWk66M3s6802pfnbLFTa/hBlnsFDtztgXQZx0tySAuonZvH4N33o9p3js0Bh7E+4TD4H5IFOeSp8/rC4+6DvULaKPEmDQ4moWvTv8kwkaNnVkSOhxbLMHRV91/q8eXuSv0S2GNCT5N+Z8vF00OanxPnkNKqf1YOvdrnEVAjAAvYYojJVE3bISx9ZGO0RGDOKKjpIwwjNs5Idv130oDDcZB2aGH9kstu7hN180v7QLYswHsDk9vzazqalDGI56KRQtnaWc1HMeX6mmWrHjsgZXJ2JWCpoxnECHTWiPuMX3TZAeYLX8vxxzlK1nvOvrAitzbbo9Q05mAn5gsMAOaxds4VAeXOfZgdnH+vBiiDdbqJhBnrTtmWh5P5ejNwWNpjsY/swBi0JAAfc1MkoAABoUFWEvJsrZ56QwMrjot4aQlq80ffVxGwL5yfQd6om0UTRbmcHeqdxXPwYEUgd53yyvTcy57FBxhK9S3+a4bII3LSyzF4T6aAFdsd3vMbN2D0SGbblaxnJF52RsDxcFF8bRu4Y6Q61IViiy1JA/nygS5pKm0yJgwoErkI/Sav08CtRr3JLCzr0VRzEx5NPW0kPx8jE69mM5FyM+6NJuQDR5r2G0aYjG52jY=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: unifyops-postgresql-secret
+      namespace: uo-dev


### PR DESCRIPTION
One PostgreSQL instance per environment, dev first (plan §5.3 step 1).

- StatefulSet `unifyops-postgresql` (db `unifyops`), Harbor-hosted Bitnami image (exact tag already running), 10Gi Longhorn PVC
- initdb ConfigMap creates `identity` + `platform` schemas on first boot
- `unifyops-postgresql-secret` — first **sealed** DB credential in the repo (old imperative secrets untouched)
- Daily pg_dumpall CronJob, 14-day retention (mirrors UO-P0-05)
- Old `auth_db`/`user_db` releases untouched; retirement is UO-P1-10

Deviation from plan: raw manifests instead of a Bitnami Helm release — Harbor hosts no postgresql chart (only image copies) and the upstream Bitnami chart source is unreliable post-Broadcom. Reported in the slice report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvHuKbtSR5MRk9u6tpeMB7