### PR TITLE
fix(gitops): track appset-secrets.yaml in apps kustomization (drift fix)

### DIFF
--- a/clusters/unifyops-home/apps/kustomization.yaml
+++ b/clusters/unifyops-home/apps/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - appset-user.yaml
   - appset-postgresql.yaml
   - appset-identity-service.yaml
+  - appset-secrets.yaml
 
   # Each subdir has its own kustomization.yaml
   - argocd/


### PR DESCRIPTION
## Summary
Preflight item from Phase 1 Slice 2: `appset-secrets.yaml` (the `sealed-secrets-management` ApplicationSet) is applied in the cluster but was missing from `clusters/unifyops-home/apps/kustomization.yaml` on main, so `root-apps` never managed it.

## Safety analysis
- Live ApplicationSet spec is **identical** to the file (verified via `last-applied-configuration` + live spec diff).
- Adding the resource makes root-apps **adopt** the existing object; only delta is the `cluster: unifyops-home` traceability label every other appset already carries.
- Generated `dev-secrets`/`staging-secrets` Applications are owned by the ApplicationSet (`prune: false` on generated apps) — no secret behavior changes.
- `kubectl kustomize` build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyDxnNqP5Zmq9pkb4oZoAj