### PR TITLE
UO-P1-06: identity-service readiness probe → /health/ready (merge after image bump)

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/identity/identity-service/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/identity/identity-service/values-dev.yaml
@@ -55,12 +55,14 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
-# Health checks
+# Health checks. Readiness includes a real DB connectivity check
+# (UO-P1-06, endpoint exists from the UO-P1-06 image onward); liveness
+# stays process-level on /health.
 probes:
   readiness:
     enabled: true
     httpGet:
-      path: "/{{ .Values.stack.appType }}/{{ .Values.stack.name }}/health"
+      path: "/{{ .Values.stack.appType }}/{{ .Values.stack.name }}/health/ready"
       port: 8001
     initialDelaySeconds: 10
     periodSeconds: 10


### PR DESCRIPTION
## Summary
Final rollout step for UO-P1-06 (unifyops #22): the readiness probe moves to `/service/identity/health/ready`, which does a real `SELECT 1` and returns 503 when the shared Postgres is unreachable. Liveness stays on process-level `/health`.

## Merge order
**Merge LAST**, after the UO-P1-06/07 image is deployed to uo-dev (infra #22 → unifyops #20–#23 → CI image bump → this). On the current image the endpoint 404s, which would only mark the pod NotReady — no crash loop — but there is no reason to merge early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyDxnNqP5Zmq9pkb4oZoAj