### PR TITLE
UO-P1-08: ApplicationSet for platform-api (dev only)

### DIFF
--- a/clusters/unifyops-home/apps/appset-platform-api.yaml
+++ b/clusters/unifyops-home/apps/appset-platform-api.yaml
@@ -1,0 +1,54 @@
+# UO-P1-08: platform-api — the single external gateway/BFF (renamed/evolved
+# from auth-api). Dev only during the Phase 1 transition; staging/prod join
+# when the slice is proven and the old services are retired (UO-P1-10).
+# The old auth/user gateways keep their own appsets until UO-P1-10.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-api
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - env: "dev"
+            branch: "dev"
+            namespace: "uo-dev"
+          # - env: "staging"
+          #   branch: "staging"
+          #   namespace: "uo-staging"
+          # prod (branch: main, namespace: uo-prod) in Phase 9
+  template:
+    metadata:
+      name: '{{env}}-platform-api'
+      labels:
+        stack: platform
+        appType: api
+        environment: '{{env}}'
+    spec:
+      project: apps
+      sources:
+        - repoURL: oci://harbor.unifyops.io/library/unifyops-stack
+          chart: unifyops-stack
+          targetRevision: "0.1.17"
+          helm:
+            valueFiles:
+              - $values/clusters/unifyops-home/apps/unifyops/gateway/platform-api/values-{{env}}.yaml
+        - repoURL: https://github.com/KominskyOrg/unifyops-infra.git
+          targetRevision: '{{branch}}'
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m

--- a/clusters/unifyops-home/apps/kustomization.yaml
+++ b/clusters/unifyops-home/apps/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - appset-user.yaml
   - appset-postgresql.yaml
   - appset-identity-service.yaml
+  - appset-platform-api.yaml
   - appset-secrets.yaml
 
   # Each subdir has its own kustomization.yaml


### PR DESCRIPTION
## Summary
- New ApplicationSet `platform-api` (dev generator only): Argo app `dev-platform-api`, chart unifyops-stack 0.1.17, values from the dev branch at `apps/unifyops/gateway/platform-api/values-dev.yaml`.
- Registered in `apps/kustomization.yaml`.
- Old auth/user appsets untouched (retirement is UO-P1-10).

## Merge order (strict)
1. This PR (main) + infra #<values PR> (dev) — the app will show Degraded/ImagePullBackOff on `platform-api:bootstrap` until step 2 publishes an image.
2. unifyops monorepo UO-P1-08 PR — its first dev build pushes the image and bumps the tag via update-gitops (which FAILS if the values file from these PRs isn't merged yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WAgni1P5cXQyqtPBzk78T