### PR TITLE
fix(dev): old auth-service signs JWTs with real auth-jwt-secret

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/identity/auth/auth-service/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/identity/auth/auth-service/values-dev.yaml
@@ -103,6 +103,17 @@ env:
         key: postgres-password
   - name: DATABASE_URL
     value: "postgresql://postgres:$(DB_PASSWORD)@auth-service-postgresql:5432/auth_db"
+  # Baseline §11-Critical-3 (live SECRET_KEY defect, old-service side): the
+  # chart's envFrom injects the JWT secret under the env name "jwt-secret",
+  # which nothing reads — without this mapping the pod signs JWTs with the
+  # compiled-in default. Same fix identity-service got in UO-P1-06.
+  # NOTE: rolling this out invalidates previously issued dev tokens
+  # (they were signed with the default key) — dev users just re-login.
+  - name: SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: auth-jwt-secret
+        key: jwt-secret
 # - name: CUSTOM_FEATURE_FLAG
 #   value: "enabled"
 # - name: EXTERNAL_API_KEY


### PR DESCRIPTION
## Summary
Optional safe fix from the Slice 3 brief: the old auth-service still signed JWTs with the compiled-in default `SECRET_KEY` in dev (Baseline §11-Critical-3, old-service side — the chart injects the secret under the unread env name `jwt-secret`). This maps it to the `SECRET_KEY` env the service actually reads, the same fix identity-service got in UO-P1-06.

## Impact
- Previously issued dev tokens become invalid (they were signed with the default key) — dev users re-login once.
- Old auth-api verifies tokens via auth-service HTTP, so the old gateway stays consistent automatically.
- values-dev only; no code changes to the old service (it retires in UO-P1-10).

Independent of the platform-api PRs — can merge any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WAgni1P5cXQyqtPBzk78T