### PR TITLE
fix(dev): disable platform-api HPA (sync-wave bootstrap deadlock)

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/gateway/platform-api/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/gateway/platform-api/values-dev.yaml
@@ -60,9 +60,12 @@ probes:
       port: 8002
     initialDelaySeconds: 30
     periodSeconds: 20
-# Autoscaling
+# Autoscaling — DISABLED for now: chart 0.1.17 renders the HPA in sync
+# wave 0 but the Deployment in wave 2, so a brand-new app deadlocks (HPA
+# unhealthy without its target -> wave 2 never applies). Re-enable after
+# the chart orders the HPA after the Deployment (follow-up ticket).
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 2
   maxReplicas: 10
   targetCPUUtilizationPercentage: 70


### PR DESCRIPTION
Chart 0.1.17 renders the HPA in sync wave 0 and the Deployment in wave 2. On a brand-new app the HPA fails health (its target Deployment doesn't exist yet), so the sync never reaches wave 2 and `dev-platform-api` sits Degraded with zero pods — exactly what happened on first deploy. Existing apps (old auth-api) never hit this because their Deployments pre-dated the HPA health gate.

Disables autoscaling for platform-api (replicaCount 1, matching identity-service in dev). Follow-up: fix wave ordering in unifyops-stack, then re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WAgni1P5cXQyqtPBzk78T