### PR TITLE
UO-P4-01: ApplicationSet for platform-service (dev only)

### DIFF
--- a/clusters/unifyops-home/apps/appset-platform-service.yaml
+++ b/clusters/unifyops-home/apps/appset-platform-service.yaml
@@ -1,0 +1,55 @@
+# UO-P4-01: platform-service — the platform-domain service (environments
+# in Phase 4; applications/deployments/jobs/audit in Phases 5-7; the
+# Phase 5 worker shares this image). Dev only for now; staging/prod join
+# in Phase 9. Owns the `platform` schema in the shared per-env PostgreSQL
+# (its Helm migration job runs the platform Alembic chain).
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-service
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - env: "dev"
+            branch: "dev"
+            namespace: "uo-dev"
+          # - env: "staging"
+          #   branch: "staging"
+          #   namespace: "uo-staging"
+          # prod (branch: main, namespace: uo-prod) in Phase 9
+  template:
+    metadata:
+      name: '{{env}}-platform-service'
+      labels:
+        stack: platform
+        appType: service
+        environment: '{{env}}'
+    spec:
+      project: apps
+      sources:
+        - repoURL: oci://harbor.unifyops.io/library/unifyops-stack
+          chart: unifyops-stack
+          targetRevision: "0.1.17"
+          helm:
+            valueFiles:
+              - $values/clusters/unifyops-home/apps/unifyops/platform/platform-service/values-{{env}}.yaml
+        - repoURL: https://github.com/KominskyOrg/unifyops-infra.git
+          targetRevision: '{{branch}}'
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m

--- a/clusters/unifyops-home/apps/kustomization.yaml
+++ b/clusters/unifyops-home/apps/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - appset-postgresql.yaml
   - appset-identity-service.yaml
   - appset-platform-api.yaml
+  - appset-platform-service.yaml
   - appset-portal.yaml
   - appset-secrets.yaml
 


### PR DESCRIPTION
Adds the `platform-service` ApplicationSet (dev generator only, chart `unifyops-stack` 0.1.17, appType `service`) and wires it into the apps kustomization. Values ride the env branches at `clusters/unifyops-home/apps/unifyops/platform/platform-service/values-{env}.yaml` — the dev values file lands via the sibling PR into `dev`.

**Merge order:** this PR and the dev-values PR must merge BEFORE the monorepo platform-service change (its update-gitops job hard-fails if the values file is missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939sGw9bL1KGHew2tyEk5t