### PR TITLE
UO-P4-01: platform-service dev values (shared PostgreSQL, platform schema)

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/platform/platform-service/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/platform/platform-service/values-dev.yaml
@@ -1,0 +1,171 @@
+# platform-service — dev values (UO-P4-01).
+# The platform-domain service (environments in Phase 4; applications/
+# deployments/jobs/audit + the worker in Phases 5-7). Runs against the
+# SHARED per-environment PostgreSQL (unifyops-postgresql, UO-P1-01),
+# platform schema; no per-service postgresql subchart. Requires
+# unifyops-stack >= 0.1.17 (database.host/existingSecret overrides for
+# the migration job and wait-for-database init containers).
+#
+# NOTE: the platform 0001 migration seeds environments by reading the
+# default org from identity.organizations — identity-service's migration
+# job must have run once on this database first (long true in uo-dev).
+
+# Global configuration
+global:
+  namespace: "uo-dev"
+  imageRegistry: "harbor.unifyops.io/library"
+  imagePullSecrets:
+    - name: harbor-registry
+# Stack configuration - This drives everything
+stack:
+  name: platform
+  appType: service
+enabled: true
+replicaCount: 1
+# Image configuration
+image:
+  repository: "platform-service"
+  tag: "bootstrap" # Updated by CI/CD workflow on the first dev build
+  pullPolicy: IfNotPresent # SHA tags are immutable, no need to always pull
+# Service configuration
+service:
+  type: ClusterIP
+  port: 8001
+  targetPort: 8001
+  annotations: {}
+# Configuration (adapts based on appType)
+config:
+  apiPort: "8001"
+  environment: "development"
+  databaseSchema: "platform"
+  skipMigrations: "true" # Migrations run via the chart migration Job only
+  logStyle: "otel"
+  enableOtelLogging: "true"
+  logLevel: "info"
+# Database configuration — shared instance, no subchart
+database:
+  enabled: true
+  # Used by the migration job / wait-for-database init containers (chart >= 0.1.17)
+  host: "unifyops-postgresql"
+  dbName: "unifyops"
+  existingSecret: "unifyops-postgresql-secret"
+  url: "postgresql://postgres:${DB_PASSWORD}@unifyops-postgresql:5432/unifyops"
+  external:
+    enabled: false
+# Resource limits
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+# Health checks. Readiness includes a real DB connectivity check;
+# liveness stays process-level on /health.
+probes:
+  readiness:
+    enabled: true
+    httpGet:
+      path: "/{{ .Values.stack.appType }}/{{ .Values.stack.name }}/health/ready"
+      port: 8001
+    initialDelaySeconds: 10
+    periodSeconds: 10
+  liveness:
+    enabled: true
+    httpGet:
+      path: "/{{ .Values.stack.appType }}/{{ .Values.stack.name }}/health"
+      port: 8001
+    initialDelaySeconds: 30
+    periodSeconds: 20
+# Autoscaling (keep disabled: chart 0.1.17 HPA sync-wave ordering deadlock)
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+# Observability (only works for api/service appTypes)
+observability:
+  enabled: false
+# Additional environment variables
+env:
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: unifyops-postgresql-secret
+        key: postgres-password
+  - name: DATABASE_URL
+    value: "postgresql://postgres:$(DB_PASSWORD)@unifyops-postgresql:5432/unifyops"
+  # Boot-guard secret (UO-P1-06): this service mints no JWTs but the
+  # shared guard requires a real SECRET_KEY — same source as every service.
+  - name: SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: auth-jwt-secret
+        key: jwt-secret
+  # Service-to-service auth (UO-P1-07): identity-service-auth-keys is the
+  # per-caller key REGISTRY for the platform — a caller presents one key
+  # everywhere. platform-api's key here is the same one it presents to
+  # identity-service; service-api-key satisfies the boot guard fallback.
+  - name: SERVICE_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: identity-service-auth-keys
+        key: service-api-key
+  - name: SERVICE_AUTH_KEY_PLATFORM_API
+    valueFrom:
+      secretKeyRef:
+        name: identity-service-auth-keys
+        key: platform-api
+  - name: SERVICE_AUTH_KEY_WORKER
+    valueFrom:
+      secretKeyRef:
+        name: identity-service-auth-keys
+        key: worker
+# Placement
+nodeSelector: {}
+tolerations: []
+affinity: {}
+# Ingress (services don't need ingress)
+ingress:
+  enabled: false
+  className: "nginx-private"
+  annotations: {}
+  hosts:
+    - host: dev.unifyops.io
+      paths:
+        - path: "/{{ .Values.stack.appType }}/{{ .Values.stack.name }}"
+          pathType: Prefix
+  tls: []
+# Secrets (boot-guard key source; see env SECRET_KEY mapping above)
+secrets:
+  existingSecret: "auth-jwt-secret"
+  existingSecretJwtKey: "jwt-secret"
+# No per-service PostgreSQL subchart: shared instance (UO-P1-01)
+postgresql:
+  enabled: false
+# Network policies
+networkPolicy:
+  enabled: true
+  defaultDeny:
+    ingress: true
+    egress: true
+# ServiceAccount
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+# Pod Security contexts
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+# Common labels
+commonLabels: {}


### PR DESCRIPTION
Dev values for the fourth deployable: shared `unifyops-postgresql`, `platform` schema, migration-job-only migrations, per-caller service-auth keys reused from the `identity-service-auth-keys` registry, `SECRET_KEY` from `auth-jwt-secret` (boot guard). `tag: bootstrap` until the first dev build bumps it.

Note: the platform 0001 migration seeds environments by reading the default org from `identity.organizations` — long present in uo-dev.

**Merge order:** merge together with the appset PR (base `main`), BEFORE the monorepo platform-service change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939sGw9bL1KGHew2tyEk5t