### PR TITLE
UO-P5-02: ApplicationSet for platform-worker (dev only)

### DIFF
--- a/clusters/unifyops-home/apps/appset-platform-worker.yaml
+++ b/clusters/unifyops-home/apps/appset-platform-worker.yaml
@@ -1,0 +1,57 @@
+# UO-P5-02: platform-worker — the job worker deployable. SAME image and
+# codebase as platform-service (update-gitops bumps both values files on a
+# platform-service build), different entrypoint (`python -m app.worker`,
+# chart 0.2.0 command override). No Service, no ingress, no migration job
+# (platform-service owns the platform Alembic chain); liveness is the
+# worker's heartbeat file via the chart's exec probe support. Dev only for
+# now; staging/prod join in Phase 9.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-worker
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - env: "dev"
+            branch: "dev"
+            namespace: "uo-dev"
+          # - env: "staging"
+          #   branch: "staging"
+          #   namespace: "uo-staging"
+          # prod (branch: main, namespace: uo-prod) in Phase 9
+  template:
+    metadata:
+      name: '{{env}}-platform-worker'
+      labels:
+        stack: platform
+        appType: worker
+        environment: '{{env}}'
+    spec:
+      project: apps
+      sources:
+        - repoURL: oci://harbor.unifyops.io/library/unifyops-stack
+          chart: unifyops-stack
+          targetRevision: "0.2.0"
+          helm:
+            valueFiles:
+              - $values/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-{{env}}.yaml
+        - repoURL: https://github.com/KominskyOrg/unifyops-infra.git
+          targetRevision: '{{branch}}'
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m

--- a/clusters/unifyops-home/apps/kustomization.yaml
+++ b/clusters/unifyops-home/apps/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - appset-identity-service.yaml
   - appset-platform-api.yaml
   - appset-platform-service.yaml
+  - appset-platform-worker.yaml
   - appset-portal.yaml
   - appset-secrets.yaml
 


### PR DESCRIPTION
New `platform-worker` ApplicationSet (dev only): shares the platform-service image with a `python -m app.worker` entrypoint via chart **0.2.0** command override. No Service/ingress/migration job; exec liveness on the worker heartbeat file.

**Merge order (strict):**
1. unifyops-helm worker-appType PR → tag `helm-v0.2.0` → chart published to Harbor
2. **this PR** (appsets live on main)
3. infra values PR (dev branch)
4. monorepo UO-P5-S1 PR (its update-gitops bumps the worker values tag)

Until step 4 lands, `dev-platform-worker` will show ImagePullBackOff on the `bootstrap` placeholder tag — expected, self-heals on the first dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)