### PR TITLE
UO-P6-04: platform-worker chart 0.2.1 (GitOps writer egress)

### DIFF
--- a/clusters/unifyops-home/apps/appset-platform-worker.yaml
+++ b/clusters/unifyops-home/apps/appset-platform-worker.yaml
@@ -33,7 +33,7 @@ spec:
       sources:
         - repoURL: oci://harbor.unifyops.io/library/unifyops-stack
           chart: unifyops-stack
-          targetRevision: "0.2.0"
+          targetRevision: "0.2.1"
           helm:
             valueFiles:
               - $values/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-{{env}}.yaml


### PR DESCRIPTION
Bumps the platform-worker ApplicationSet chart pin 0.2.0 → 0.2.1 so the dev worker can opt into `networkPolicy.workerHttpsEgress` (UO-P6 slice 3 GitOps writer needs HTTPS egress to GitHub).

**Merge order (strict):**
1. unifyops-helm#8 (publishes chart 0.2.1) — FIRST
2. this PR (main appset pin)
3. unifyops-infra dev PR (worker values env + sealed secret)
4. unifyops monorepo slice-3 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBzXYSod3ARNpB6eN9E7Hh