### PR TITLE
UO-P6-04: dev worker GitOps writer env + HTTPS egress

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-dev.yaml
@@ -107,6 +107,30 @@ env:
       secretKeyRef:
         name: identity-service-auth-keys
         key: service-api-key
+  # GitOps writer (UO-P6 slice 3): the worker commits rendered tenant
+  # desired state to unifyops-infra (tenants/** only — the writer's path
+  # guard enforces it; CI's GITOPS_PAT/clusters/** image bumps are a
+  # SEPARATE token and author). Branch dev = this environment's branch.
+  - name: GITOPS_REPO_URL
+    value: "https://github.com/KominskyOrg/unifyops-infra.git"
+  - name: GITOPS_BRANCH
+    value: "dev"
+  - name: GITOPS_TENANT_ROOT
+    value: "tenants"
+  - name: GITOPS_COMMIT_AUTHOR_NAME
+    value: "unifyops-platform"
+  - name: GITOPS_COMMIT_AUTHOR_EMAIL
+    value: "platform@unifyops.io"
+  # Fine-grained GitHub token, contents:write on unifyops-infra ONLY
+  # (gitops-writer-token sealed secret). optional: the worker boots
+  # without it and deployment jobs fail CLEARLY with
+  # error_type=gitops_credentials_missing instead of the pod crashing.
+  - name: GITOPS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: gitops-writer-token
+        key: token
+        optional: true
 # Placement
 nodeSelector: {}
 tolerations: []
@@ -123,12 +147,14 @@ secrets:
 postgresql:
   enabled: false
 # Network policies: worker branch = deny-all ingress, egress to the
-# in-namespace postgresql primary + DNS only.
+# in-namespace postgresql primary + DNS, plus HTTPS (chart 0.2.1
+# workerHttpsEgress) so the GitOps writer can reach GitHub.
 networkPolicy:
   enabled: true
   defaultDeny:
     ingress: true
     egress: true
+  workerHttpsEgress: true
 # ServiceAccount (zero cluster permissions; automount stays off)
 serviceAccount:
   create: true

--- a/clusters/unifyops-home/secrets/dev/gitops-writer-token-sealed.yaml
+++ b/clusters/unifyops-home/secrets/dev/gitops-writer-token-sealed.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: gitops-writer-token
+  namespace: uo-dev
+spec:
+  encryptedData:
+    token: AgCGyPpWNofEvUzRH4dfgCzY5v8o/UMQiMCb7/cVYCbPt4JLRGiV3WcDkoQMR3MPaBJwaJjuxHNRXaO63TjwrdYIq4kgkQCltZwUpNapy/0XWVz/B68BoKJ6//hwi9NrCONSZFFIOQU6oh7NE/iGNHiDYkogv59r/t0T2gChJYC4e+FCJShzasla5VMaW55YRNZwDr/ftJXbX8RkUWVXbQr5rfE0F+e0SGrvtPkLXX7XvTfbIa9AqQigCzJI/wfQwme0XApOq6bXJKWX30gMS2gvjAReCUu1NWN28xLmoDYvXkwGL3u/VdW93PNOGcqyqdXr4S/qzd3UDIp878F6n2zkaA8MrPBxXYUI+C3VeKG3sJhQf23YVCrCzX5z9pp65hvoinsqHsWX1KC6rNlesEdVAPXF3QQ5N6svSQW0GWW3DkBb4Llin6KyaT2HBir2jeLE6w5WlZRqq/G2yaG0XnRD1i7EST+ANMbDCKZ9cNFArtC+x5EimCMbnMe3xiCWELZKgBXUDB+6AHyOAIcd0V9in7XXRAOwh46veJdZ1MDahubgAIhVlVvRBHhPb5N9jnFQmj0JGDXHYakoDdS+Ycxb48SIi/aqECLkiigX7p/hjhb/reED9fcgN/oFAiRFNVyMxke7U+wS/FIEtAJY2hGh090bI2R/rOLuueQuQM+z6O3FYPrtpXQHfZw7cbhOD7N60HlRSs91iimvl56Mva+M8SNDn+s58un7Cw9yF2AA4JXNTOefPUpH5SqhR0iA4E/HTwyFHbN0BlR+yocT2oC4Mt5NUpEOc/VHvjuw3LU9E9qijxudrDVGtMMTD9k=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: gitops-writer-token
+      namespace: uo-dev

--- a/clusters/unifyops-home/secrets/dev/kustomization.yaml
+++ b/clusters/unifyops-home/secrets/dev/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: uo-dev
 
 resources:
   - auth-jwt-sealed.yaml
+  - gitops-writer-token-sealed.yaml
   - auth-service-api-keys-sealed.yaml
   - identity-service-auth-keys-sealed.yaml
   - unifyops-postgresql-sealed.yaml


### PR DESCRIPTION
## UO-P6 slice 3 — dev worker wiring for the GitOps writer

- `GITOPS_REPO_URL/BRANCH/TENANT_ROOT/COMMIT_AUTHOR_*` env on dev-platform-worker (branch `dev`, tenant root `tenants/` — the writer's path guard hard-fails anything else; CI's `GITOPS_PAT` image bumps under `clusters/**` remain a separate token/author).
- `GITOPS_TOKEN` from the `gitops-writer-token` sealed secret, **`optional: true`**: the worker boots without it; deployment jobs fail clearly with `error_type=gitops_credentials_missing` until the secret exists (never a crash-loop, never a silent skip).
- `networkPolicy.workerHttpsEgress: true` (chart 0.2.1) so the writer can reach GitHub over 443.

### Owner action required (before live verification)
Mint a **fine-grained GitHub PAT**: resource owner `KominskyOrg`, repository access **only `unifyops-infra`**, permission **Contents: Read and write**, nothing else. Then either paste it to the session agent to seal, or run:

```bash
kubectl -n uo-dev create secret generic gitops-writer-token \
  --from-literal=token='<PAT>' --dry-run=client -o yaml \
| kubeseal --controller-namespace sealed-secrets --format yaml \
> clusters/unifyops-home/secrets/dev/gitops-writer-token-sealed.yaml
```
and add `- gitops-writer-token-sealed.yaml` to `clusters/unifyops-home/secrets/dev/kustomization.yaml` (the sealed file + kustomization entry will be pushed to this branch).

### Merge order (strict)
1. unifyops-helm#8 (chart 0.2.1) — merged & published FIRST
2. unifyops-infra#36 (main appset pin 0.2.1)
3. **this PR** (dev values + sealed secret)
4. unifyops monorepo slice-3 PR

Safety: no Argo app/appset watches `tenants/**` (verified against `main`, which root-apps tracks) — tenant files written by the worker create NO Kubernetes resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBzXYSod3ARNpB6eN9E7Hh