### PR TITLE
UO-P6 slice 4: dev tenant ApplicationSet + tenants AppProject (dev only)

### DIFF
--- a/clusters/unifyops-home/apps/appset-tenant-apps-dev.yaml
+++ b/clusters/unifyops-home/apps/appset-tenant-apps-dev.yaml
@@ -1,0 +1,65 @@
+# UO-P6 slice 4: dev tenant applications — the FIRST consumer of
+# tenants/**. A git files generator watches EXACTLY
+# tenants/default/dev/*/values.yaml on the dev branch (single `*` does
+# not cross `/`, so staging/prod/other-org paths can never match) and
+# renders one Application per tenant app from the platform worker's
+# generated chart-consumable values.
+#
+# Safety properties (do not weaken):
+# - Application name + destination derive from the PATH, never from
+#   file content — a crafted values file cannot redirect the deploy.
+# - The destination namespace is hardcoded to t-default-dev and the
+#   `tenants` AppProject only allows that destination + a narrow
+#   resource whitelist (no Secret/Job/Ingress).
+# - Namespace creation is CreateNamespace=true, i.e. dev-only by
+#   construction (this is the only tenant appset).
+# - prune: true is deliberate: deleting a tenant values file deletes
+#   the generated Application (ApplicationSet ownership) and its
+#   resources; values edits that drop a resource prune it likewise.
+# staging/prod tenant appsets are a later, explicit slice.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenant-apps-dev
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/KominskyOrg/unifyops-infra.git
+        revision: dev
+        files:
+          - path: tenants/default/dev/*/values.yaml
+  template:
+    metadata:
+      name: 't-default-dev-{{path.basename}}'
+      labels:
+        tenant-org: default
+        environment: dev
+        tenant-app: '{{path.basename}}'
+    spec:
+      project: tenants
+      sources:
+        - repoURL: oci://harbor.unifyops.io/library/unifyops-stack
+          chart: unifyops-stack
+          targetRevision: "0.2.1"
+          helm:
+            valueFiles:
+              - $values/{{path}}/values.yaml
+        - repoURL: https://github.com/KominskyOrg/unifyops-infra.git
+          targetRevision: dev
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: t-default-dev
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m

--- a/clusters/unifyops-home/apps/kustomization.yaml
+++ b/clusters/unifyops-home/apps/kustomization.yaml
@@ -25,6 +25,8 @@ resources:
   - appset-platform-worker.yaml
   - appset-portal.yaml
   - appset-secrets.yaml
+  # UO-P6 slice 4: dev tenant apps (tenants/default/dev/*/values.yaml)
+  - appset-tenant-apps-dev.yaml
 
   # Each subdir has its own kustomization.yaml
   - argocd/

--- a/clusters/unifyops-home/projects/tenants-project.yaml
+++ b/clusters/unifyops-home/projects/tenants-project.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: tenants
+  namespace: argocd
+spec:
+  description: >-
+    UnifyOps tenant applications (UO-P6 slice 4). DEV ONLY: the single
+    allowed destination is the derived dev tenant namespace. Widening
+    this project (staging/prod destinations, more resource kinds) is a
+    deliberate later-slice decision — do not widen casually.
+  sourceRepos:
+    - 'https://github.com/KominskyOrg/unifyops-infra.git'
+    - 'oci://harbor.unifyops.io/library/unifyops-stack'
+  destinations:
+    # Exactly the dev tenant namespace for the default org — NOT t-*.
+    # tenants/default/staging|prod (and any other org) stay undeployable
+    # until a future slice adds them here explicitly.
+    - namespace: t-default-dev
+      server: https://kubernetes.default.svc
+  clusterResourceWhitelist:
+    # CreateNamespace=true needs to create t-default-dev; nothing else
+    # cluster-scoped is permitted.
+    - group: ""
+      kind: Namespace
+  namespaceResourceWhitelist:
+    # Exactly what unifyops-stack renders for appType `app` (the only
+    # shape the platform worker generates). Deliberately ABSENT: Secret,
+    # Job, Ingress — a hand-crafted tenant values file trying to render
+    # those (appType service/api, ingress.enabled) fails the project
+    # check instead of deploying.
+    - group: "apps"
+      kind: Deployment
+    - group: ""
+      kind: Service
+    - group: ""
+      kind: ConfigMap
+    - group: ""
+      kind: ServiceAccount
+    - group: "networking.k8s.io"
+      kind: NetworkPolicy
+    - group: "autoscaling"
+      kind: HorizontalPodAutoscaler

--- a/scripts/validate-tenant-appset.sh
+++ b/scripts/validate-tenant-appset.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# UO-P6 slice 4: guardrail checks for the dev tenant ApplicationSet.
+#
+# Proves, without a cluster:
+#   1. the git files generator watches EXACTLY
+#      tenants/default/dev/*/values.yaml (no tenants/** breadth, no
+#      staging/prod match, no non-values files, single-segment glob);
+#   2. a sample tenant values path templates into a valid, DNS-safe,
+#      deterministic Application targeting t-default-dev in the
+#      `tenants` project;
+#   3. the `tenants` AppProject stays narrow (only the t-default-dev
+#      destination; cluster-scoped whitelist = Namespace only; no
+#      Secret/Job/Ingress in the namespaced whitelist).
+#
+# Run from the repo root: ./scripts/validate-tenant-appset.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+python3 - <<'PY'
+import re
+import sys
+
+import yaml
+
+APPSET_PATH = "clusters/unifyops-home/apps/appset-tenant-apps-dev.yaml"
+PROJECT_PATH = "clusters/unifyops-home/projects/tenants-project.yaml"
+
+failures = []
+
+
+def check(condition, message):
+    if condition:
+        print(f"  ok: {message}")
+    else:
+        failures.append(message)
+        print(f"  FAIL: {message}")
+
+
+with open(APPSET_PATH, encoding="utf-8") as fh:
+    appset = yaml.safe_load(fh)
+with open(PROJECT_PATH, encoding="utf-8") as fh:
+    project = yaml.safe_load(fh)
+
+print("[1] generator narrowness")
+generators = appset["spec"]["generators"]
+check(len(generators) == 1, "exactly one generator")
+git_gen = generators[0].get("git", {})
+check(git_gen.get("revision") == "dev", "generator revision is dev")
+files = git_gen.get("files", [])
+check(len(files) == 1, "exactly one files pattern")
+pattern = files[0].get("path", "")
+check(
+    pattern == "tenants/default/dev/*/values.yaml",
+    f"pattern is exactly tenants/default/dev/*/values.yaml (got {pattern!r})",
+)
+raw_code_lines = [
+    line
+    for line in open(APPSET_PATH, encoding="utf-8").read().splitlines()
+    if not line.lstrip().startswith("#")
+]
+check(
+    all("**" not in line for line in raw_code_lines),
+    "no ** glob anywhere in the appset (comments excluded)",
+)
+
+print("[2] glob semantics (segment-wise, * must not cross /)")
+import fnmatch
+
+
+def glob_matches(pattern: str, candidate: str) -> bool:
+    p_parts = pattern.split("/")
+    c_parts = candidate.split("/")
+    if len(p_parts) != len(c_parts):
+        return False
+    return all(fnmatch.fnmatchcase(c, p) for p, c in zip(p_parts, c_parts))
+
+
+must_match = ["tenants/default/dev/p6s4-demo/values.yaml"]
+must_not_match = [
+    "tenants/default/staging/p6s4-demo/values.yaml",
+    "tenants/default/prod/p6s4-demo/values.yaml",
+    "tenants/other-org/dev/p6s4-demo/values.yaml",
+    "tenants/default/dev/p6s4-demo/extra/values.yaml",
+    "tenants/default/dev/p6s4-demo/config.json",
+    "tenants/default/dev/values.yaml",
+    "clusters/unifyops-home/apps/unifyops/portal/values-dev.yaml",
+]
+for candidate in must_match:
+    check(glob_matches(pattern, candidate), f"matches {candidate}")
+for candidate in must_not_match:
+    check(not glob_matches(pattern, candidate), f"does NOT match {candidate}")
+
+print("[3] template renders a valid dev-only Application")
+template_raw = yaml.safe_dump(appset["spec"]["template"])
+sample_dir = "tenants/default/dev/p6s4-demo"
+rendered_raw = (
+    template_raw.replace("{{path.basename}}", sample_dir.rsplit("/", 1)[-1])
+    .replace("{{path}}", sample_dir)
+)
+check("{{" not in rendered_raw, "no unsubstituted template params for file generator paths")
+app = yaml.safe_load(rendered_raw)
+name = app["metadata"]["name"]
+check(name == "t-default-dev-p6s4-demo", f"deterministic name (got {name!r})")
+check(
+    re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name) is not None,
+    "Application name is DNS-safe",
+)
+dest = app["spec"]["destination"]
+check(dest["namespace"] == "t-default-dev", "destination namespace is exactly t-default-dev")
+check(app["spec"]["project"] == "tenants", "project is tenants")
+sources = app["spec"]["sources"]
+chart_sources = [s for s in sources if s.get("chart") == "unifyops-stack"]
+check(len(chart_sources) == 1, "one unifyops-stack chart source")
+check(
+    isinstance(chart_sources[0]["targetRevision"], str),
+    "chart version pinned as a string",
+)
+value_files = chart_sources[0]["helm"]["valueFiles"]
+check(
+    value_files == [f"$values/{sample_dir}/values.yaml"],
+    "values file comes from the matched tenant path",
+)
+ref_sources = [s for s in sources if s.get("ref") == "values"]
+check(
+    len(ref_sources) == 1 and ref_sources[0]["targetRevision"] == "dev",
+    "$values ref source pinned to the dev branch",
+)
+sync_options = app["spec"]["syncPolicy"].get("syncOptions", [])
+check("CreateNamespace=true" in sync_options, "CreateNamespace=true present")
+
+print("[4] tenants AppProject narrowness")
+destinations = project["spec"]["destinations"]
+check(
+    destinations == [{"namespace": "t-default-dev", "server": "https://kubernetes.default.svc"}],
+    "project destinations are exactly [t-default-dev] (no wildcard)",
+)
+cluster_wl = project["spec"]["clusterResourceWhitelist"]
+check(
+    cluster_wl == [{"group": "", "kind": "Namespace"}],
+    "cluster-scoped whitelist is Namespace only",
+)
+ns_kinds = {entry["kind"] for entry in project["spec"]["namespaceResourceWhitelist"]}
+check("*" not in ns_kinds, "no wildcard kind in the namespaced whitelist")
+for forbidden in ("Secret", "Job", "Ingress"):
+    check(forbidden not in ns_kinds, f"{forbidden} not deployable by tenant apps")
+
+print()
+if failures:
+    print(f"{len(failures)} check(s) FAILED")
+    sys.exit(1)
+print("all tenant-appset guardrail checks passed")
+PY


### PR DESCRIPTION
## Phase 6 Slice 4 (infra half) — merge FIRST (inert until tenant files exist)

Makes Argo consume tenant desired state, **dev only**.

- **appset-tenant-apps-dev**: git files generator watching EXACTLY `tenants/default/dev/*/values.yaml` on the `dev` branch (single `*` cannot cross `/` → staging/prod/other-org/nested/non-values paths can never match). One Application per tenant app: unifyops-stack **0.2.1** (already published) + the generated values via the `$values` ref pattern. Application name (`t-default-dev-{{path.basename}}`) and destination derive from the PATH only — file content cannot redirect the deploy. Automated sync + prune + selfHeal; `CreateNamespace=true` (namespace creation is dev-only by construction — this is the only tenant appset). Deleting a values file deletes the generated Application + resources (documented prune choice).
- **tenants AppProject** (new, minimal): single destination `t-default-dev` (the `apps` project only allows `uo-*`, so tenant apps get their own narrow project); cluster-scoped whitelist = Namespace only; namespaced whitelist = exactly what appType `app` renders (Deployment/Service/ConfigMap/ServiceAccount/NetworkPolicy/HPA) — **no Secret/Job/Ingress**, so a crafted tenant file trying appType service/api or ingress fails the project check.
- **scripts/validate-tenant-appset.sh**: guardrail checks (generator narrowness, glob semantics incl. staging/prod non-match, template renders a valid DNS-safe dev-only Application, project narrowness) — all passing; `kubectl kustomize` build verified; sample generated values proven against the chart with `helm template` (renders exactly the whitelisted kinds, all in t-default-dev).

After merge: root-apps picks up the appset; it should generate **0 Applications** (no tenants/ dir exists on dev). Live tenant deployment verification follows the monorepo PR (unifyops#44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KriAyQtXFrkbghznw1XM3i