### PR TITLE
chore: pin platform-worker to chart 0.2.2 (worker /tmp emptyDir)

### DIFF
--- a/clusters/unifyops-home/apps/appset-platform-worker.yaml
+++ b/clusters/unifyops-home/apps/appset-platform-worker.yaml
@@ -33,7 +33,7 @@ spec:
       sources:
         - repoURL: oci://harbor.unifyops.io/library/unifyops-stack
           chart: unifyops-stack
-          targetRevision: "0.2.1"
+          targetRevision: "0.2.2"
           helm:
             valueFiles:
               - $values/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-{{env}}.yaml


### PR DESCRIPTION
Owner follow-up (P5S1 §18.3). Requires chart 0.2.2 published to Harbor first (unifyops-helm PR + manual publish dispatch). Merge order: helm PR → publish 0.2.2 → this → infra dev readOnlyRootFilesystem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KriAyQtXFrkbghznw1XM3i