### PR TITLE
chore(dev): worker readOnlyRootFilesystem=true (chart 0.2.2)

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-dev.yaml
@@ -173,7 +173,9 @@ securityContext:
   capabilities:
     drop:
       - ALL
-  readOnlyRootFilesystem: false
+  # true since chart 0.2.2: workers get a /tmp emptyDir (heartbeat file +
+  # GitOps writer temp clones), so the rootfs can be read-only.
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
 # Common labels


### PR DESCRIPTION
Owner follow-up (P5S1 §18.3). Merge AFTER the 0.2.2 worker appset pin is merged and the worker is Healthy on 0.2.2 (/tmp emptyDir present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KriAyQtXFrkbghznw1XM3i