### PR TITLE
chore(harbor): move admin password to a SealedSecret

### DIFF
--- a/clusters/unifyops-home/apps/harbor/app.yaml
+++ b/clusters/unifyops-home/apps/harbor/app.yaml
@@ -12,7 +12,13 @@ spec:
     helm:
       values: |
         externalURL: https://harbor.unifyops.io
-        harborAdminPassword: "Y7gRUdjSi1W42maVxlTuKw=="
+        # Admin password comes from the harbor-admin SealedSecret
+        # (secrets/harbor-admin.sealed.yaml) — never plaintext in git.
+        # NOTE: the chart only consumes this at initial install; the live
+        # password lives in Harbor's DB. Rotation = change it in Harbor,
+        # then re-seal the new value here.
+        existingSecretAdminPassword: harbor-admin
+        existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
         expose:
           type: ingress
           tls:

--- a/clusters/unifyops-home/apps/harbor/kustomization.yaml
+++ b/clusters/unifyops-home/apps/harbor/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - app.yaml
   - certificate.yaml
   - secrets/route53-credentials.sealed.yaml
+  - secrets/harbor-admin.sealed.yaml

--- a/clusters/unifyops-home/apps/harbor/secrets/harbor-admin.sealed.yaml
+++ b/clusters/unifyops-home/apps/harbor/secrets/harbor-admin.sealed.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: harbor-admin
+  namespace: harbor-system
+spec:
+  encryptedData:
+    HARBOR_ADMIN_PASSWORD: AgA1/beyzOn1fZQ8+It/rbJJCFrLUvxntfDPPLsx7Q51kLBeEg7T3wZr/ksOA/LZr24XUonrZMhikvi7TZ0GRi+beq7TrMPDQpqm9hjPlPXDoy8pYdtpClz2zlKmj0u24H3RfJVdI03lr+4pUn7zk+QVN0DpRtu+r/fvjKhQDYtiDPdzOPKHl69KDVdfP7MPgJXh7UQo+SfQ8lFQxLU9t+5saZfMFYvU415U+WukrR6/NGSMi+nWl0gl0mEvx1a7SYENn4eyU1QLyjMvEOq67E2TPhDOXmZulQPM1nrdiAH/0CnSxd0Sw7HlSAsCKEi4yGeUPfG6DShczM4aGXmU/lT6VBSbnRUrV/aZF3C80JxuBbUZfIdGYGmyrTuuK86U/c7ItW3EHRu/k8L+UrbTsH0WiO3NxrJ9hltkUJkT4tWzDzYPAIDnpop4F6r89O/2ZfD1tyl2B67ZpqpctmVr7irAkhrqiL23rPtC97pJAh3SyE5MmVKl9LYeBbgKAwTaGRlpyZHl1mXx5nbZpdva9mRDHFGbcm4UmvBH943UMDgU5Ac8n8lcs42Htgm+r8mnjlTg+XyzUdgmBo0SRrk/UvSLQEStgZCnBvoZVgZmkOh4Ub0umIUzcLHMTde6FWuA6IYOjNZ3a3z/YM56jawcoiBkaT1Xpp1Gdth6UDJ8Cyu4w6pqU0/hi89SgAC+x7khHsM+cmPNzkSi0NJCLTbg0RmGe0PQSwb5p2I=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: harbor-admin
+      namespace: harbor-system


### PR DESCRIPTION
Owner follow-up. Same value sealed into harbor-system/harbor-admin (kubeseal, plaintext never on disk); app.yaml switches to existingSecretAdminPassword. Zero runtime impact (the chart only reads it at initial install). The old value stays in git history — rotating the Harbor admin password and re-sealing is a recommended follow-up owner decision (other consumers unaudited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KriAyQtXFrkbghznw1XM3i