### PR TITLE
UO-P6 slice 5: dev worker Argo status credentials + registry allowlist

### DIFF
--- a/clusters/unifyops-home/apps/unifyops/platform/platform-service/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/platform/platform-service/values-dev.yaml
@@ -88,6 +88,10 @@ observability:
   enabled: false
 # Additional environment variables
 env:
+  # Registry allowlist (owner follow-up, UO-P6 slice 5): the application
+  # registry only accepts Harbor-hosted image repositories in dev.
+  - name: ALLOWED_IMAGE_REPOSITORY_PREFIXES
+    value: "harbor.unifyops.io/"
   - name: DB_PASSWORD
     valueFrom:
       secretKeyRef:

--- a/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-dev.yaml
+++ b/clusters/unifyops-home/apps/unifyops/platform/platform-worker/values-dev.yaml
@@ -130,6 +130,30 @@ env:
       secretKeyRef:
         name: gitops-writer-token
         key: token
+  # Argo status observation (UO-P6 slice 5): READ-ONLY project-scoped
+  # token (account uo-status-reader, RBAC = applications get tenants/*
+  # only). In-cluster service URL; self-signed cert -> verify off (the
+  # ingress hostname rides Tailscale and is not pod-reachable).
+  # optional: without the token, dev deployment jobs fail CLEARLY with
+  # error_type=argo_credentials_missing instead of the pod crashing.
+  - name: ARGO_BASE_URL
+    value: "https://argocd-server.argocd.svc.cluster.local"
+  - name: ARGO_TLS_VERIFY
+    value: "false"
+  - name: ARGO_APP_NAMESPACE
+    value: "argocd"
+  - name: ARGO_PROJECT
+    value: "tenants"
+  - name: ARGO_POLL_INTERVAL_SECONDS
+    value: "3"
+  - name: ARGO_SYNC_TIMEOUT_SECONDS
+    value: "300"
+  - name: ARGO_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: argo-status-token
+        key: token
+        optional: true
         optional: true
 # Placement
 nodeSelector: {}

--- a/clusters/unifyops-home/secrets/dev/argo-status-token-sealed.yaml
+++ b/clusters/unifyops-home/secrets/dev/argo-status-token-sealed.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: argo-status-token
+  namespace: uo-dev
+spec:
+  encryptedData:
+    token: AgCyckLIIHTAxZEyvZC06UMFmEL8RDG8lYh4VGOLpqnWLj2Go6jpKWD5uSYxzIG/Ah/n6xu3Nc6A5PC+if+4B3vE5Qx7eVuNtDRMmmMiXB7vcoYriYTEPGa82Hk7rlxLBDb9NQHHdVKZnp8gDne4IoLSR/x/uCnWhKT+WiFj1/FnYUqokiQ9U9g71Ny0WAiM+MAS4mJA68wSOVhOpa8FHqKAOLJOb6Q6NJJXOnPKkTP0ES/OsHlsq5MxU/sSj65bC2QZn8aEdGk0gADlEZk3/Osj4MFRpoDk5tF5n1+0urQWp+27eOMzgutydRUKJBoiEOP0N9OhzQtNJCHhB1lAlc54QxiRKTys0LyF9bE3IwsnacICDNMXcOmCk4K6K5RAEw7UnM9S7d6BdVE8e9/iNhfJvPnTl7bJLPGIB8dAMlhXmhflW3RgMWwhAvrOetX6VDUby/I2Ukd9hb5wIHCcZLRr2aRM8Ny9xUvDqtZNSBgS0eCRCjRmke86z0NjIRiIPrC2w86IYdCcl6qMqOylJ/Q4bZHdiK2Fu5nYCWvYMwOq4eNwvLJp//W9WS+qucE9JDrfdIq+GsT00n86lj+dJqi8UJ7DF0dMvQaqa6JeMLtT2/GztmCPs0RYSn38Jjy/YtJFZQ7TV18NARUSusAEAn7XKh3q5SjjFxM4+mtYOQEfagjUFA1tjkzBRWtBZ5SSvJJPtesgj8XKjago3p6b016TVQ++vULv4MkHCCyP82+mGe5iuItRByGghZ4xzyLkepzRUl2lujaItVotzzPdKBy1oO4kXQhR9SDLQutlKizBrIOidgxV3ecyxVZo9pUX3b0QfYUXXXyE/90aFTgXZc/CgQxwkd3qf/H14BDAtUpgHtbY1cuqGb2b9xtfTSIhtCNII8R6J1dAlL6plRTXUSdsuiJH3fQThL/296+lg1GffWWMV9uHi0yWYjayUNIybg3jzrYKoGTpyZaGQ1veApwGohBPXaqOpbH8icqbJj5QYvdSwURDZ+6KwGHifELO5V7HauzmteVQRtQwbw==
+  template:
+    metadata:
+      creationTimestamp: null
+      name: argo-status-token
+      namespace: uo-dev

--- a/clusters/unifyops-home/secrets/dev/kustomization.yaml
+++ b/clusters/unifyops-home/secrets/dev/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: uo-dev
 resources:
   - auth-jwt-sealed.yaml
   - gitops-writer-token-sealed.yaml
+  - argo-status-token-sealed.yaml
   - auth-service-api-keys-sealed.yaml
   - identity-service-auth-keys-sealed.yaml
   - unifyops-postgresql-sealed.yaml


### PR DESCRIPTION
## Phase 6 Slice 5 (infra half) — merge FIRST

- `argo-status-token` sealed secret (uo-dev): API-key token for the new Argo local account **uo-status-reader** — RBAC is exactly `applications get tenants/*` (read-only, proven live: 0 platform apps visible, 403 on foreign reads, no writes). Admin password was rotated out-of-band first (prior exposure) and the stale initial-admin secret deleted.
- platform-worker values: `ARGO_BASE_URL` (in-cluster argocd-server — the public hostname rides Tailscale and is not pod-reachable), `ARGO_TLS_VERIFY=false` (self-signed in-cluster cert, dev-only, documented), poll 3s / timeout 300s, `ARGO_TOKEN` secretKeyRef (optional:true → clear job failure `argo_credentials_missing`, never a crash-loop). Worker-only — platform-api/portal never see the credential.
- platform-service values: `ALLOWED_IMAGE_REPOSITORY_PREFIXES=harbor.unifyops.io/` (registry allowlist owner item).

No appset/chart changes; no new deployable. Merge before unifyops#45 so the env+secret exist when the new worker image deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KriAyQtXFrkbghznw1XM3i